### PR TITLE
Add ARM64 support to managed RuntimeInformation APIs.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixArchitecture.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixArchitecture.cs
@@ -16,7 +16,8 @@ internal static partial class Interop
         {
             x86,
             x64,
-            ARM
+            ARM,
+            ARM64
         }
     }
 }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -27,7 +27,8 @@ namespace System.Runtime.InteropServices
     {
         X86,
         X64,
-        Arm
+        Arm,
+        Arm64
     }
 
     public static partial class RuntimeInformation

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/Architecture.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/Architecture.cs
@@ -8,6 +8,7 @@ namespace System.Runtime.InteropServices
     {
         X86,
         X64,
-        Arm
+        Arm,
+        Arm64
     }
 }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -50,6 +50,10 @@ namespace System.Runtime.InteropServices
                             case Interop.Sys.ProcessorArchitecture.x86:
                                 s_osArch = Architecture.X86;
                                 break;
+
+                            case Interop.Sys.ProcessorArchitecture.ARM64:
+                                s_osArch = Architecture.Arm64;
+                                break;
                         }
                     }
                 }
@@ -67,7 +71,11 @@ namespace System.Runtime.InteropServices
                 {
                     if (null == s_processArch)
                     {
-                        if (Architecture.Arm == OSArchitecture)
+                        if (Architecture.Arm64 == OSArchitecture)
+                        {
+                            s_processArch = s_is64BitProcess ? Architecture.Arm64 : Architecture.Arm;
+                        }
+                        else if (Architecture.Arm == OSArchitecture)
                         {
                             s_processArch = Architecture.Arm;
                         }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -29,6 +29,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.Equal(Architecture.Arm, processArch);
                     break;
 
+                case Architecture.Arm64:
+                    Assert.Equal(IntPtr.Size == 4 ? Architecture.Arm : Architecture.Arm64, processArch);
+                    break;
+
                 default:
                     Assert.False(true, "Unexpected Architecture.");
                     break;


### PR DESCRIPTION
@manu-silicon I've done the work to add Arm64 to the public contract surface area of RuntimeInformation. Merging this commit to your branch, will add it to the already open PR against corefx.

This can be incorporated to corefx only after API-Review. Thanks!
